### PR TITLE
Add inactive indicator on transaction preview

### DIFF
--- a/frontend/src/pages/StakingAmountPage/index.tsx
+++ b/frontend/src/pages/StakingAmountPage/index.tsx
@@ -219,6 +219,7 @@ const StakingAmountPageCmp: FC = () => {
                     )
                   })()}
                   {StringUtils.getValidatorFriendlyAddress(validator)}
+                  {!validator.active && <p className="body mute">(inactive)</p>}
                 </p>,
               ],
               [

--- a/frontend/src/pages/UnstakePage/index.tsx
+++ b/frontend/src/pages/UnstakePage/index.tsx
@@ -268,6 +268,7 @@ const UnstakePageCmp: FC = () => {
                     )
                   })()}
                   {StringUtils.getValidatorFriendlyAddress(validator)}
+                  {!validator.active && <p className="body mute">(inactive)</p>}
                 </p>,
               ],
               [


### PR DESCRIPTION
## Solution

Add `(inactive)` indicator on (un)stake transaction preview, in case validator is not active.

## Resources

![localhost_5173_](https://github.com/user-attachments/assets/f6fd3033-5d99-4bdc-8754-4df83b5d060c)
