### PR TITLE
move: Prevent middleEllipsis adding newline to copied address

### DIFF
--- a/move/src/components/ShortAddress/index.module.css
+++ b/move/src/components/ShortAddress/index.module.css
@@ -1,11 +1,15 @@
 .middleEllipsis {
   display: flex;
+  display: inline-block;
   white-space: nowrap;
   user-select: all;
   max-width: 15.1ch;
   transition: max-width 600ms ease-out;
 
   > :first-child {
+    display: inline-block;
+    vertical-align: middle;
+    max-width: calc(100% - 8ch);
     text-overflow: ellipsis;
     overflow: hidden;
     min-width: 5ch;
@@ -13,5 +17,7 @@
 
   > :last-child {
     flex-shrink: 0;
+    display: inline-block;
+    vertical-align: middle;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/rose/issues/79