### PR TITLE
Redirect from old URLs to new URLs

### DIFF
--- a/home/public/move/index.html
+++ b/home/public/move/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="shortcut icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/move/">
+  </head>
+  <body>
+    <!-- Fallback redirect from old URL -->
+  </body>
+</html>

--- a/home/public/stake/index.html
+++ b/home/public/stake/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="shortcut icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/stake/">
+  </head>
+  <body>
+    <!-- Fallback redirect from old URL -->
+  </body>
+</html>


### PR DESCRIPTION
When we switched to single-page app navigation, we had to switch to hash router to continue deploying on github pages. But this broke links from blog posts.

Fixes 85767112ba92233e603e10594b1f232911567b5b.