### PR TITLE
home: Remove / in redirects

### DIFF
--- a/home/public/discover/index.html
+++ b/home/public/discover/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="shortcut icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/discover/" />
+    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/discover" />
   </head>
   <body>
     <!-- Fallback redirect from old URL -->

--- a/home/public/move/index.html
+++ b/home/public/move/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="shortcut icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/move/" />
+    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/move" />
   </head>
   <body>
     <!-- Fallback redirect from old URL -->

--- a/home/public/stake/index.html
+++ b/home/public/stake/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="shortcut icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/stake/" />
+    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/stake" />
   </head>
   <body>
     <!-- Fallback redirect from old URL -->

--- a/home/public/wrap/index.html
+++ b/home/public/wrap/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="shortcut icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/wrap/" />
+    <meta http-equiv="refresh" content="0;url=https://rose.oasis.io/#/wrap" />
   </head>
   <body>
     <!-- Fallback redirect from old URL -->


### PR DESCRIPTION
Due to how analytics collects paths, there are now 2 entries for some of the entries, like `/discover` and `/discover/`. Other possible way to fix this would be to modify the submitted url in `FathomAnalytics.tsx`(in case it ends with slash, remove it).