### PR TITLE
Assemble changes for 1.0.2 release

### DIFF
--- a/.changelog/204.bugfix.md
+++ b/.changelog/204.bugfix.md
@@ -1,1 +1,0 @@
-wrap: Fix BN to bigint conversion

--- a/.changelog/205.trivial.md
+++ b/.changelog/205.trivial.md
@@ -1,1 +1,0 @@
-Temporary bring back GH pages deploy

--- a/.changelog/206.bugfix.md
+++ b/.changelog/206.bugfix.md
@@ -1,1 +1,0 @@
-Show correct ROSE App version in footer

--- a/.changelog/207.bugfix.md
+++ b/.changelog/207.bugfix.md
@@ -1,1 +1,0 @@
-move: Fix race conditions when withdrawing to second destination address

--- a/.changelog/209.internal.md
+++ b/.changelog/209.internal.md
@@ -1,1 +1,0 @@
-Fix pnpm cache and install order in CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ The format is inspired by [Keep a Changelog].
 
 <!-- TOWNCRIER -->
 
+## 1.0.2 (2025-02-21)
+
+### Bug Fixes and Improvements
+
+- wrap: Fix BN to bigint conversion
+  ([#204](https://github.com/oasisprotocol/rose-app/issues/204))
+
+- Show correct ROSE App version in footer
+  ([#206](https://github.com/oasisprotocol/rose-app/issues/206))
+
+- move: Fix race conditions when withdrawing to second destination address
+  ([#207](https://github.com/oasisprotocol/rose-app/issues/207))
+
+### Internal Changes
+
+- Fix pnpm cache and install order in CI
+  ([#209](https://github.com/oasisprotocol/rose-app/issues/209))
+
 ## 1.0.1 (2025-02-17)
 
 ### Internal Changes


### PR DESCRIPTION
These fixes were requested to be included in a next deploy/infra switch:

Once merged:
- disable gh pages workflow
- enable release workflow