### PR TITLE
e2e: Run preview on e2e tests

### DIFF
--- a/.changelog/255.internal.md
+++ b/.changelog/255.internal.md
@@ -1,0 +1,1 @@
+e2e: Run preview on e2e tests

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+
+    headless: !!process.env.CI,
   },
 
   /* Configure projects for major browsers */

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
+    baseURL: 'http://localhost:4173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -42,8 +42,9 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'pnpm --filter @oasisprotocol/rose-app-home dev',
-    url: 'http://localhost:5173',
+    command:
+      'pnpm --filter @oasisprotocol/rose-app-home build && pnpm --filter @oasisprotocol/rose-app-home preview',
+    url: 'http://localhost:4173',
     reuseExistingServer: !process.env.CI,
   },
 })

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:4173',
+    baseURL: 'http://localhost:5173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -44,9 +44,10 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command:
-      'pnpm --filter @oasisprotocol/rose-app-home build && pnpm --filter @oasisprotocol/rose-app-home preview',
-    url: 'http://localhost:4173',
+    command: process.env.CI
+      ? 'pnpm --filter @oasisprotocol/rose-app-home build && pnpm --filter @oasisprotocol/rose-app-home preview --port 5173'
+      : 'pnpm --filter @oasisprotocol/rose-app-home dev',
+    url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
   },
 })

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -5,6 +5,12 @@ test.describe('navigation', () => {
     page.on('pageerror', error => {
       throw error
     })
+
+    page.on('console', message => {
+      if (message.type() === 'error') {
+        throw new Error(`Console error: ${message.text()}`)
+      }
+    })
   })
 
   test.afterEach(async ({ page }) => {
@@ -13,22 +19,22 @@ test.describe('navigation', () => {
   })
 
   test('home page', async ({ page }) => {
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'networkidle' })
   })
 
   test('discover page', async ({ page }) => {
-    await page.goto('/#/discover')
+    await page.goto('/#/discover', { waitUntil: 'networkidle' })
   })
 
   test('stake page', async ({ page }) => {
-    await page.goto('/#/stake')
+    await page.goto('/#/stake', { waitUntil: 'networkidle' })
   })
 
   test('move page', async ({ page }) => {
-    await page.goto('/#/move')
+    await page.goto('/#/move', { waitUntil: 'networkidle' })
   })
 
   test('wrap page', async ({ page }) => {
-    await page.goto('/#/wrap')
+    await page.goto('/#/wrap', { waitUntil: 'networkidle' })
   })
 })


### PR DESCRIPTION
This is needed to detect ``WagmiProviderNotFoundError: `useConfig` must be used within `WagmiProvider`.  WagmiProviderNotFoundError`` that appeared on dev deploy after https://github.com/oasisprotocol/rose-app/pull/253 until https://github.com/oasisprotocol/rose-app/pull/254

(same thing happened in https://github.com/oasisprotocol/rose-app/pull/179)