### PR TITLE
Use the correct SPDX License identifier in package.json

### DIFF
--- a/.changelog/259.trivial.md
+++ b/.changelog/259.trivial.md
@@ -1,0 +1,1 @@
+Use the correct SPDX License identifier in package.json

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "pnpm --filter=!@oasisprotocol/rose-app-e2e --parallel -r exec vitest run --passWithNoTests",
     "test-e2e": "pnpm --filter @oasisprotocol/rose-app-e2e test"
   },
-  "license": "See License in LICENSE",
+  "license": "Apache-2.0",
   "packageManager": "pnpm@8.15.4",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
According to [NPM docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#license):

> If you're using a common license such as BSD-2-Clause or MIT,
> add a current [SPDX license identifier](https://spdx.org/licenses/) for the license you're using,

So, we should use "Apache-2.0" here.
