### PR TITLE
Catch timeout error in waitForTransactionReceipt

### DIFF
--- a/.changelog/269.bugfix.md
+++ b/.changelog/269.bugfix.md
@@ -1,0 +1,1 @@
+Catch timeout error in waitForTransactionReceipt


### PR DESCRIPTION
Errors thrown inside sendTransactionAsync.onSuccess were ignored.

Part of https://github.com/oasisprotocol/rose-app/issues/247