### PR TITLE
move: Remove oasisscan as an alternative source for consensus nonce

### DIFF
--- a/.changelog/273.bugfix.md
+++ b/.changelog/273.bugfix.md
@@ -1,0 +1,1 @@
+move: Fix by removing oasisscan as an alternative source for consensus nonce


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/rose-app/issues/272

Reverts part of e44c3e25da45fc01ad0ba1df51f95ca88882e9bf