### PR TITLE
Discovery: remove duplicate logo (on mobile)

### DIFF
--- a/.changelog/283.trivial.md
+++ b/.changelog/283.trivial.md
@@ -1,0 +1,1 @@
+Remove duplicate logo from Discovery (on mobile)

--- a/discover/src/App.tsx
+++ b/discover/src/App.tsx
@@ -1,19 +1,13 @@
 import { FC } from 'react'
-import { useMediaQuery } from 'react-responsive'
 import { Layout, Card } from '@oasisprotocol/rose-app-ui/discover'
 import { CARDS_CONFIG } from './constants/config'
-
 import classes from './App.module.css'
-import { Logo, Header } from '@oasisprotocol/rose-app-ui/core'
 
 const { featured, dApps, tooling } = CARDS_CONFIG
 
 export const App: FC = () => {
-  const isMobileScreen = useMediaQuery({ query: '(max-width: 1023px)' })
-
   return (
     <Layout>
-      <Header logo={isMobileScreen && <Logo />} />
       <div className={classes.app}>
         <h1 className={classes.discoverTitle}>Discover</h1>
         <div className={classes.featured}>


### PR DESCRIPTION
Normally, the logo is only displayed once, but in the Discovery module, at mobil sizes, it was uselessly repeated.

This change fixes that.

| Before | After |
| --- | --- |
| <img width="608" height="1123" alt="image" src="https://github.com/user-attachments/assets/72eabf71-4db7-427e-b18d-f687d026988c" />  |  <img width="611" height="1121" alt="image" src="https://github.com/user-attachments/assets/fd474878-5acb-40b4-aaa2-c5e5a3efc277" />  |