### PR TITLE
wrap: Show error message if amount can not be parsed

### DIFF
--- a/.changelog/303.trivial.md
+++ b/.changelog/303.trivial.md
@@ -1,0 +1,1 @@
+wrap: Show error message if amount can not be parsed

--- a/wrap/src/components/WrapForm/index.tsx
+++ b/wrap/src/components/WrapForm/index.tsx
@@ -90,19 +90,23 @@ export const WrapForm: FC = () => {
     setError('')
     e.preventDefault()
 
-    const amount = NumberUtils.BigIntToBN(parseEther(value || '0'))
+    try {
+      const amount = NumberUtils.BigIntToBN(parseEther(value || '0'))
 
-    if (
-      formType === WrapFormType.WRAP &&
-      NumberUtils.shouldShowWrapFeeWarningModal({
-        fee: estimatedFee,
-        amount,
-        accountBalanceAmount: balance,
-      })
-    ) {
-      setIsWrapFeeModalOpen(true)
-    } else {
-      submitTransaction(amount)
+      if (
+        formType === WrapFormType.WRAP &&
+        NumberUtils.shouldShowWrapFeeWarningModal({
+          fee: estimatedFee,
+          amount,
+          accountBalanceAmount: balance,
+        })
+      ) {
+        setIsWrapFeeModalOpen(true)
+      } else {
+        submitTransaction(amount)
+      }
+    } catch (ex) {
+      setError((ex as BaseError)?.shortMessage || (ex as Error)?.message || JSON.stringify(ex))
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/rose-app/issues/301
<img width="627" height="418" alt="image" src="https://github.com/user-attachments/assets/0fc1ed01-6664-41e0-86bd-4ff5b4cbb4f2" />
