### PR TITLE
Fix renovate by enabling cloneSubmodules option

### DIFF
--- a/.changelog/307.internal.md
+++ b/.changelog/307.internal.md
@@ -1,0 +1,1 @@
+Fix renovate by enabling cloneSubmodules option

--- a/renovate.json
+++ b/renovate.json
@@ -26,5 +26,6 @@
       "rangeStrategy": "auto"
     }
   ],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "cloneSubmodules": true
 }


### PR DESCRIPTION
Right now renovate is creating pullrequests that remove 1000 lines from lockfile
https://github.com/oasisprotocol/rose-app/pull/306/commits/a709365ab93e6d53daba90f963df45b80b1836f1

`"cloneSubmodules": true` fixes it